### PR TITLE
[#18] [tec] Execute migrations at Heroku starting

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rails db:migrate && bundle exec rails server


### PR DESCRIPTION
Provide a Procfile which executes migrations (rails db:migrate) and then
starts the server (rails server). It makes running migrations after deploying
optional.